### PR TITLE
Remove incorrect task filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Builds your Android project with Gradle.
 <summary>Description</summary>
 
 
-The Step builds your Android project on Bitrise with Gradle commands: it installs all dependences that are listed in the project's `build.gradle` file, and builds and exports either an APK or an AAB.
+The Step builds your Android project on Bitrise with Gradle commands: it installs all dependencies that are listed in the project's `build.gradle` file, and builds and exports either an APK or an AAB.
 Once the file is exported, it is available for other Steps in your Workflow.
 
 You can select the module and the variant you want to use for the build.
@@ -95,7 +95,7 @@ Build a release AAB:
 | --- | --- | --- | --- |
 | `project_location` | The root directory of your Android project. For example, where your root build gradle file exist (also gradlew, settings.gradle, and so on) | required | `$BITRISE_SOURCE_DIR` |
 | `module` | Set the module that you want to build. To see your available modules, please open your project in Android Studio and go in [Project Structure] and see the list on the left.  |  |  |
-| `variant` | Set the variant(s) that you want to build. To see your available variants, please open your project in Android Studio and go in [Project Structure] -> variants section. You can set multiple variants separated by `\n` character. For instance: `- variant: myvariant1\nmyvariant2`.  |  |  |
+| `variant` | Set the variant(s) that you want to build. To see your available variants,  open your project in Android Studio and go in [Project Structure] -> variants section.  You can set multiple variants separated by a new line (`\n`), such as `myvariant1\nmyvariant2`.  |  |  |
 | `build_type` | Set the build type that you want to build.  | required | `apk` |
 | `app_path_pattern` | Will find the APK or AAB files - depending on the **Build type** input - with the given pattern.<br/> Separate patterns with a newline. **Note**<br/> The Step will export only the selected artifact type even if the filter would accept other artifact types as well.  | required | `*/build/outputs/apk/*.apk */build/outputs/bundle/*.aab` |
 | `cache_level` | `all` - The Step will cache build cache and the dependencies `only_deps` - The Step will cache dependencies only `none` - The Step will not cache anything | required | `only_deps` |

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 workflows:
 
   test_nested_module:
-    title: Test simple Android project with nested module
+    title: Test simple Android project with nested application module
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/android-multiple-test-results-sample.git
     - BRANCH: maintenance
@@ -21,6 +21,29 @@ workflows:
         - gradlew_path: ./gradlew
     - path::./:
         title: Test nested module
+        inputs:
+        - module: app:nested_app
+        - variant: release
+
+  test_multiple_variants:
+    title: Test building multiple variants
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/android-multiple-test-results-sample.git
+    - BRANCH: maintenance
+    - EXPECTED_APK: nested_app-release-unsigned.apk
+    - EXPECTED_APK_PATH_LIST: $BITRISE_DEPLOY_DIR/nested_app-debug.apk|$BITRISE_DEPLOY_DIR/nested_app-release-unsigned.apk
+    - EXPECTED_MAPPING: app-mapping.txt
+    before_run:
+    - _setup
+    after_run:
+    - _check_apk
+    - _check_mapping
+    steps:
+    - install-missing-android-tools:
+        inputs:
+        - gradlew_path: ./gradlew
+    - path::./:
+        title: Execute step
         inputs:
         - module: app:nested_app
         - variant: |-
@@ -173,6 +196,15 @@ workflows:
               echo "Expected APK ($EXPECTED_APK) is not found in deploy dir:"
               ls -la $BITRISE_DEPLOY_DIR
               exit 1
+            fi
+            
+            if [ -n "$EXPECTED_APK_PATH_LIST" ] ; then
+              if [ "$EXPECTED_APK_PATH_LIST" != "$BITRISE_APK_PATH_LIST" ] ; then
+                echo "Expected APK path list does not match actual step output"
+                echo "Expected: $EXPECTED_APK_PATH_LIST"
+                echo "Actual: $BITRISE_APK_PATH_LIST"
+                exit 1
+              fi
             fi
 
   _check_aab:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -8,8 +8,13 @@ workflows:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/android-multiple-test-results-sample.git
     - BRANCH: maintenance
+    - EXPECTED_APK: nested_app-release-unsigned.apk
+    - EXPECTED_MAPPING: app-mapping.txt
     before_run:
     - _setup
+    after_run:
+    - _check_apk
+    - _check_mapping
     steps:
     - install-missing-android-tools:
         inputs:
@@ -17,7 +22,8 @@ workflows:
     - path::./:
         title: Test nested module
         inputs:
-        - module: app:mylibrary
+        - module: app:nested_app
+        - variant: release
 
   test_simple_apk:
     title: Test simple Android project and APK building
@@ -43,7 +49,7 @@ workflows:
         - arguments: --warn
 
   test_monorepo_apk:
-    title: Test project in monorepo and APK building
+    title: Test multiple separate projects in a monorepo and APK building
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/android-testing.git
     - BRANCH: maintenance
@@ -90,7 +96,7 @@ workflows:
         - build_type: aab
 
   test_monorepo_aab:
-    title: Test project in monorepo and AAB building
+    title: Test multiple separate projects in a monorepo and AAB building
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/android-testing.git
     - BRANCH: maintenance

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -30,9 +30,9 @@ workflows:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/android-multiple-test-results-sample.git
     - BRANCH: maintenance
-    - EXPECTED_APK: nested_app-release-unsigned.apk
-    - EXPECTED_APK_PATH_LIST: $BITRISE_DEPLOY_DIR/nested_app-debug.apk|$BITRISE_DEPLOY_DIR/nested_app-release-unsigned.apk
-    - EXPECTED_MAPPING: app-mapping.txt
+    - EXPECTED_APK: another_app-full-release-unsigned.apk
+    - EXPECTED_APK_PATH_LIST: $BITRISE_DEPLOY_DIR/another_app-demo-release-unsigned.apk|$BITRISE_DEPLOY_DIR/another_app-full-release-unsigned.apk
+    - EXPECTED_MAPPING: another_app-mapping.txt
     before_run:
     - _setup
     after_run:
@@ -45,10 +45,10 @@ workflows:
     - path::./:
         title: Execute step
         inputs:
-        - module: app:nested_app
+        - module: another_app
         - variant: |-
-            release
-            debug
+            fullRelease
+            demoRelease
 
   test_simple_apk:
     title: Test simple Android project and APK building
@@ -161,22 +161,6 @@ workflows:
         - repository_url: $TEST_APP_URL
         - clone_into_dir: .
         - branch: $BRANCH
-    - script:
-        run_if: $.IsCI
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-            if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-              sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
-              sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
-              export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
-              envman add --key JAVA_HOME --value "/usr/lib/jvm/java-11-openjdk-amd64"
-            elif [[ "$OSTYPE" == "darwin"* ]]; then
-              jenv global 11 || jenv global 11.0
-              export JAVA_HOME="$(jenv prefix)"
-              envman add --key JAVA_HOME --value "$(jenv prefix)"
-            fi
 
   _check_apk:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -197,7 +197,7 @@ workflows:
               ls -la $BITRISE_DEPLOY_DIR
               exit 1
             fi
-            
+
             if [ -n "$EXPECTED_APK_PATH_LIST" ] ; then
               if [ "$EXPECTED_APK_PATH_LIST" != "$BITRISE_APK_PATH_LIST" ] ; then
                 echo "Expected APK path list does not match actual step output"

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -11,8 +11,6 @@ workflows:
     - EXPECTED_APK: mylibrary-debug-androidTest.apk
     before_run:
     - _setup
-    after_run:
-    - _check_apk
     steps:
     - install-missing-android-tools:
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -8,7 +8,6 @@ workflows:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/android-multiple-test-results-sample.git
     - BRANCH: maintenance
-    - EXPECTED_APK: mylibrary-debug-androidTest.apk
     before_run:
     - _setup
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -23,7 +23,9 @@ workflows:
         title: Test nested module
         inputs:
         - module: app:nested_app
-        - variant: release
+        - variant: |-
+            release
+            debug
 
   test_simple_apk:
     title: Test simple Android project and APK building

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func run() int {
 
 	if err := androidBuild.Export(result, config.DeployDir); err != nil {
 		logger.Errorf("Export outputs: %s", err.Error())
-		return 1
+		return 0 // Export is optional, should not mark the step as failed
 	}
 
 	androidBuild.CollectCache(config)

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func run() int {
 
 	if err := androidBuild.Export(result, config.DeployDir); err != nil {
 		logger.Errorf("Export outputs: %s", err.Error())
-		return 0 // Export is optional, should not mark the step as failed
+		return 1
 	}
 
 	androidBuild.CollectCache(config)

--- a/step.yml
+++ b/step.yml
@@ -92,11 +92,11 @@ inputs:
 - variant: ""
   opts:
     title: Variant
-    summary: |
-      Set the variant(s) that you want to build. To see your available variants, please open your project in Android Studio and go in [Project Structure] -> variants section.
+    summary: Set the build variant you want to create, such as `debug` or `myflavorRelease`. To see your available variants, open your project in Android Studio and go in [Project Structure] -> variants section.
     description: |
-      Set the variant(s) that you want to build. To see your available variants, please open your project in Android Studio and go in [Project Structure] -> variants section.
-      You can set multiple variants separated by `\n` character. For instance: `- variant: myvariant1\nmyvariant2`.
+      Set the variant(s) that you want to build. To see your available variants,  open your project in Android Studio and go in [Project Structure] -> variants section.
+
+      You can set multiple variants separated by a new line (`\n`), such as `myvariant1\nmyvariant2`.
     is_required: false
 - build_type: apk
   opts:

--- a/step/step.go
+++ b/step/step.go
@@ -34,8 +34,8 @@ type Input struct {
 type Config struct {
 	ProjectLocation string
 
-	Variant string
-	Module  string
+	Variants []string
+	Module   string
 
 	AppPathPattern string
 	AppType        string
@@ -100,7 +100,7 @@ func (a AndroidBuild) ProcessConfig() (Config, error) {
 	return Config{
 		ProjectLocation: input.ProjectLocation,
 		AppPathPattern:  input.AppPathPattern,
-		Variant:         input.Variant,
+		Variants:        strings.Split(input.Variant, "\n"),
 		Module:          input.Module,
 		AppType:         input.BuildType,
 		Arguments:       args,
@@ -297,12 +297,16 @@ func (a AndroidBuild) getArtifacts(gradleProject GradleProjectWrapper, started t
 func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 	a.logger.Infof("Run build:")
 
-	taskName, err := gradleTaskName(cfg.AppType, cfg.Module, cfg.Variant)
-	if err != nil {
-		return err
+	var tasks []string
+	for _, variant := range cfg.Variants {
+		taskName, err := gradleTaskName(cfg.AppType, cfg.Module, variant)
+		if err != nil {
+			return err
+		}
+		tasks = append(tasks, taskName)
 	}
 
-	cmdArgs := append([]string{taskName}, cfg.Arguments...)
+	cmdArgs := append(tasks, cfg.Arguments...)
 	cmdOpts := command.Opts{
 		Dir:    cfg.ProjectLocation,
 		Stdout: os.Stdout,

--- a/step/step.go
+++ b/step/step.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/sliceutil"
 	"github.com/kballard/go-shellquote"
 )
 
@@ -320,23 +319,6 @@ func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 	}
 
 	return nil
-}
-
-func (a AndroidBuild) printVariants(variants, filteredVariants gradle.Variants) {
-	a.logger.Println()
-	a.logger.Infof("Variants:")
-
-	for module, variants := range variants {
-		a.logger.Printf("%s:", module)
-		for _, variant := range variants {
-			if sliceutil.IsStringInSlice(variant, filteredVariants[module]) {
-				a.logger.Donef("✓ %s", variant)
-				continue
-			}
-			a.logger.Printf("- %s", variant)
-		}
-	}
-	a.logger.Println()
 }
 
 func (a AndroidBuild) printAppSearchInfo(appArtifacts []gradle.Artifact, appPathPatterns []string) {

--- a/step/step.go
+++ b/step/step.go
@@ -77,7 +77,8 @@ const (
 	mappingFilePattern = "*build/*/mapping.txt"
 )
 
-var ignoredSuffixes = [...]string{"Classes", "Resources", "UnitTestClasses", "AndroidTestClasses", "AndroidTestResources"}
+// TODO: explain
+var ignoredTaskSuffixes = [...]string{"Classes", "Resources", "UnitTestClasses", "AndroidTestClasses", "AndroidTestResources"}
 
 // NewAndroidBuild ...
 func NewAndroidBuild(inputParser stepconf.InputParser, logger log.Logger, cmdFactory command.Factory) *AndroidBuild {
@@ -377,7 +378,7 @@ func filterNonUtilityVariants(variants []string) []string {
 
 	for _, v := range variants {
 		shouldIgnore := false
-		for _, suffix := range ignoredSuffixes {
+		for _, suffix := range ignoredTaskSuffixes {
 			if strings.HasSuffix(v, suffix) {
 				shouldIgnore = true
 				break

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -12,194 +12,7 @@ import (
 	"github.com/bitrise-steplib/bitrise-step-android-build/step/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
-
-func TestFilterVariants(t *testing.T) {
-	variants := gradle.Variants{
-		"module1": []string{"variant1", "variant2", "variant3", "variant4", "variant5", "shared", "shared2"},
-		"module2": []string{"2variant1", "2variant2", "shared", "2variant3", "2variant4", "2variant5", "shared2"},
-	}
-
-	t.Log("exact match for module and variant")
-	{
-		filtered, err := filterVariants("module1", "variant3", variants)
-		require.NoError(t, err)
-
-		expectedVariants := gradle.Variants{
-			"module1": []string{"variant3"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-
-		_, err = filterVariants("module1", "variant100", variants)
-		require.Error(t, err)
-
-		_, err = filterVariants("module100", "variant100", variants)
-		require.Error(t, err)
-
-		_, err = filterVariants("module100", "variant1", variants)
-		require.Error(t, err)
-	}
-
-	t.Log("exact match for module")
-	{
-		filtered, err := filterVariants("module1", "", variants)
-		require.NoError(t, err)
-
-		expectedVariants := gradle.Variants{
-			"module1": []string{"variant1", "variant2", "variant3", "variant4", "variant5", "shared", "shared2"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-
-		_, err = filterVariants("module3", "", variants)
-		require.Error(t, err)
-	}
-
-	t.Log("exact match for variant")
-	{
-		filtered, err := filterVariants("", "variant2", variants)
-		require.NoError(t, err)
-
-		expectedVariants := gradle.Variants{
-			"module1": []string{"variant2"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-
-		filtered, err = filterVariants("", "", variants)
-		require.NoError(t, err)
-		require.Equal(t, variants, filtered)
-
-		filtered, err = filterVariants("", "shared", variants)
-		require.NoError(t, err)
-
-		expectedVariants = gradle.Variants{
-			"module1": []string{"shared"},
-			"module2": []string{"shared"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-	}
-
-	t.Log("check no overlapping variants")
-	{
-		variants := gradle.Variants{
-			"module1": []string{"variant1", "variant12"},
-		}
-
-		filtered, err := filterVariants("module1", "variant1", variants)
-		require.NoError(t, err)
-
-		expectedVariants := gradle.Variants{
-			"module1": []string{"variant1"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-	}
-
-	t.Log("exact match for module and multiple variants")
-	{
-		filtered, err := filterVariants("module1", `variant1\nvariant2`, variants)
-		require.NoError(t, err)
-
-		expectedVariants := gradle.Variants{
-			"module1": []string{"variant1", "variant2"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-	}
-
-	t.Log("exact match for multiple variants")
-	{
-		filtered, err := filterVariants("", `shared\nshared2`, variants)
-		require.NoError(t, err)
-
-		expectedVariants := gradle.Variants{
-			"module1": []string{"shared", "shared2"},
-			"module2": []string{"shared", "shared2"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-	}
-
-	t.Log("filter out utility variants")
-	{
-		variants := gradle.Variants{
-			"module1": []string{
-				"DemoDebug", "DemoDebugAndroidTestClasses", "DemoDebugAndroidTestResources",
-				"DemoDebugClasses", "DemoDebugResources", "DemoDebugUnitTestClasses",
-				"DemoRelease", "DemoReleaseClasses", "DemoReleaseResources", "DemoReleaseUnitTestClasses",
-			},
-		}
-
-		filtered, err := filterVariants("module1", "", variants)
-		require.NoError(t, err)
-
-		expectedVariants := gradle.Variants{
-			"module1": []string{"DemoDebug", "DemoRelease"},
-		}
-
-		require.Equal(t, expectedVariants, filtered)
-	}
-
-	t.Log("exact match for module and single not existing variant")
-	{
-		_, err := filterVariants("module1", "not-existings-variant", variants)
-		require.Error(t, err)
-	}
-
-	t.Log("single not existing variant")
-	{
-		_, err := filterVariants("", "not-existings-variant", variants)
-		require.Error(t, err)
-	}
-
-	t.Log("exact match for module and multiple variants, single not existing")
-	{
-		_, err := filterVariants("module1", `variant1\nnot-existings-variant`, variants)
-		require.Error(t, err)
-	}
-
-	t.Log("multiple variants, single not existing")
-	{
-		_, err := filterVariants("", `variant2\nnot-existings-variant`, variants)
-		require.Error(t, err)
-	}
-}
-
-func TestVariantSeparation(t *testing.T) {
-	testCases := []struct {
-		title             string
-		variantsAsOneLine string
-		want              []string
-	}{
-		{
-			"1. Given multiple variants",
-			`variant1\nvariant2`,
-			[]string{"variant1", "variant2"},
-		},
-		{
-			"2. Given single variant",
-			`variant1`,
-			[]string{"variant1"},
-		},
-		{
-			"3. Given empty variant",
-			``,
-			[]string{""},
-		},
-	}
-
-	for _, testCase := range testCases {
-		// When
-		variants := separateVariants(testCase.variantsAsOneLine)
-
-		// Then
-		require.Equal(t, testCase.want, variants)
-	}
-}
 
 func Test_GivenMatchingFiles_WhenGettingArtifacts_ThenArtifactsReturned(t *testing.T) {
 	// Given
@@ -260,5 +73,82 @@ func createStep() AndroidBuild {
 		inputParser: stepconf.NewInputParser(envRepository),
 		logger:      log.NewLogger(),
 		cmdFactory:  command.NewFactory(envRepository),
+	}
+}
+
+func Test_gradleTaskName(t *testing.T) {
+	type args struct {
+		appType string
+		module  string
+		variant string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "No module, no variant",
+			args: args{
+				appType: "apk",
+				module:  "",
+				variant: "",
+			},
+			want: "assemble",
+		},
+		{
+			name: "App module, no variant",
+			args: args{
+				appType: "aab",
+				module:  "app",
+				variant: "",
+			},
+			want: ":app:bundle",
+		},
+		{
+			name: "No module, debug variant",
+			args: args{
+				appType: "apk",
+				module:  "",
+				variant: "debug",
+			},
+			want: "assembleDebug",
+		},
+		{
+			name: "App module, release variant",
+			args: args{
+				appType: "aab",
+				module:  "app",
+				variant: "release",
+			},
+			want: ":app:bundleRelease",
+		},
+		{
+			name: "Nested module, flavor variant",
+			args: args{
+				appType: "apk",
+				module:  "core:ui",
+				variant: "demoRelease",
+			},
+			want: ":core:ui:assembleDemoRelease",
+		},
+		{
+			name: "Module input starts with colon",
+			args: args{
+				appType: "aab",
+				module:  ":core:ui",
+				variant: "demoRelease",
+			},
+			want: ":core:ui:bundleDemoRelease",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gradleTaskName(tt.args.appType, tt.args.module, tt.args.variant)
+			if err != nil {
+				t.Errorf("Error: %v", err)
+			}
+			assert.Equalf(t, tt.want, got, "gradleTaskName(%v, %v, %v)", tt.args.appType, tt.args.module, tt.args.variant)
+		})
 	}
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Fixes #39 by removing the variant and task filtering logic completely. The step is trying to be too clever here, we can easily build the final Gradle task name from the `module`, `variant` and `app_type` inputs.

I created a truth table of the combinations:



| module | variant (flavor+type) | task (assuming APK)|
|-- | -- | --|
|- | - | assemble|
|app | debug | :app:assembleDebug|
|app | - | :app:assemble|
|- | debug | assembleDebug|

This works correctly because of the dependency between Gradle tasks, such as:

1. Not defining a variant in the task name runs the task for all variants (such as assemble -> assembleDebug, assembleRelease)
2. Not defining a module in the task name (although not recommended) runs the task in all submodules.

The only difference between the old and this implementation: when the variant input is not defined, the old implementation selected the `:module:assembleVariantAndroidTest` and `:module:assembleVariantUnitTest` variants for execution too. I find it unnecessary and counter-intuitive, I think it's an improvement to prevent these tasks from running.


### Changes

- Remove old code that parses the available Gradle tasks and filters them according to modules and variants
- Create a simple function that builds the final Gradle tasks based on the module, variant and app_type inputs

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

Rewriting the Gradle logic in `go-android` is out of scope for now, we can gradually review the other Android steps, and once every step is using this simpler Gradle handling, we can consolidate the common implementation in the library.
