### PR TITLE
Fix relative project paths

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -310,7 +310,7 @@ func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 	cmdOpts := command.Opts{
 		Dir:    cfg.ProjectLocation,
 		Stdout: os.Stdout,
-		Stderr: os.Stdin,
+		Stderr: os.Stderr,
 	}
 	absPath, err := filepath.Abs(cfg.ProjectLocation)
 	if err != nil {

--- a/step/step.go
+++ b/step/step.go
@@ -312,7 +312,11 @@ func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 		Stdout: os.Stdout,
 		Stderr: os.Stdin,
 	}
-	cmd := a.cmdFactory.Create(filepath.Join(cfg.ProjectLocation, "gradlew"), cmdArgs, &cmdOpts)
+	absPath, err := filepath.Abs(cfg.ProjectLocation)
+	if err != nil {
+		return err
+	}
+	cmd := a.cmdFactory.Create(filepath.Join(absPath, "gradlew"), cmdArgs, &cmdOpts)
 
 	a.logger.Println()
 	a.logger.Donef("$ " + cmd.PrintableCommandArgs())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Fixes the regression spotted in #44 when using relative project locations instead of `$BITRISE_SOURCE_DIR` or one of its subdirectories.

### Changes

Always use the absolute path when invoking Gradle, the `project_location` input sometimes can be a relative path.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
