### PR TITLE
Use relative project path in tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -84,17 +84,13 @@ workflows:
     after_run:
     - _check_apk
     steps:
-    - change-workdir:
-        title: cd ./ui/espresso/IdlingResourceSample
-        inputs:
-        - path: ./ui/espresso/IdlingResourceSample
-        - is_create_path: true
     - install-missing-android-tools:
         inputs:
-        - gradlew_path: ./gradlew
+        - gradlew_path: ui/espresso/IdlingResourceSample/gradlew
     - path::./:
         title: Test monorepo
         inputs:
+        - project_location: ui/espresso/IdlingResourceSample
         - variant: Debug
 
   test_simple_aab:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Follow-up to #45 

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

Instead of changing the workdir in one of the E2E tests, use the `project_path` input to test that logic in the step.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
