### PR TITLE
Handle old way of variant listing too

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Build a release AAB:
 | --- | --- | --- | --- |
 | `project_location` | The root directory of your Android project. For example, where your root build gradle file exist (also gradlew, settings.gradle, and so on) | required | `$BITRISE_SOURCE_DIR` |
 | `module` | Set the module that you want to build. To see your available modules, please open your project in Android Studio and go in [Project Structure] and see the list on the left.  |  |  |
-| `variant` | Set the variant(s) that you want to build. To see your available variants,  open your project in Android Studio and go in [Project Structure] -> variants section.  You can set multiple variants separated by a new line (`\n`), such as `myvariant1\nmyvariant2`.  |  |  |
+| `variant` | Set the build variants you want to create. To see your available variants,  open your project in Android Studio and go in [Project Structure] -> variants section.  This input also accepts multiple variants, separated by a line break.  |  |  |
 | `build_type` | Set the build type that you want to build.  | required | `apk` |
 | `app_path_pattern` | Will find the APK or AAB files - depending on the **Build type** input - with the given pattern.<br/> Separate patterns with a newline. **Note**<br/> The Step will export only the selected artifact type even if the filter would accept other artifact types as well.  | required | `*/build/outputs/apk/*.apk */build/outputs/bundle/*.aab` |
 | `cache_level` | `all` - The Step will cache build cache and the dependencies `only_deps` - The Step will cache dependencies only `none` - The Step will not cache anything | required | `only_deps` |

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -84,17 +84,13 @@ workflows:
     after_run:
     - _check_apk
     steps:
-    - change-workdir:
-        title: cd ./ui/espresso/IdlingResourceSample
-        inputs:
-        - path: ./ui/espresso/IdlingResourceSample
-        - is_create_path: true
     - install-missing-android-tools:
         inputs:
-        - gradlew_path: ./gradlew
+        - gradlew_path: ui/espresso/IdlingResourceSample/gradlew
     - path::./:
         title: Test monorepo
         inputs:
+        - project_location: ui/espresso/IdlingResourceSample
         - variant: Debug
 
   test_simple_aab:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -46,6 +46,21 @@ workflows:
         title: Execute step
         inputs:
         - module: another_app
+        - variant: |-
+            fullRelease
+            demoRelease
+    - script:
+        title: Clean up APKs from previous build
+        inputs:
+        - content: |-
+            set -ex
+            
+            rm -rf $BITRISE_DEPLOY_DIR/*.apk
+    - path::./:
+        title: Execute step (compatibility mode)
+        description: The step used to split multiple variants by the "\n" substring instead of a literal line break
+        inputs:
+        - module: another_app
         - variant: fullRelease\ndemoRelease
 
   test_simple_apk:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -46,9 +46,7 @@ workflows:
         title: Execute step
         inputs:
         - module: another_app
-        - variant: |-
-            fullRelease
-            demoRelease
+        - variant: fullRelease\ndemoRelease
 
   test_simple_apk:
     title: Test simple Android project and APK building

--- a/step.yml
+++ b/step.yml
@@ -92,11 +92,11 @@ inputs:
 - variant: ""
   opts:
     title: Variant
-    summary: Set the build variant you want to create, such as `debug` or `myflavorRelease`. To see your available variants, open your project in Android Studio and go in [Project Structure] -> variants section.
+    summary: Set the build variants you want to create, such as `debug` or `myflavorRelease`. To see your available variants, open your project in Android Studio and go in [Project Structure] -> variants section.
     description: |
-      Set the variant(s) that you want to build. To see your available variants,  open your project in Android Studio and go in [Project Structure] -> variants section.
+      Set the build variants you want to create. To see your available variants,  open your project in Android Studio and go in [Project Structure] -> variants section.
 
-      You can set multiple variants separated by a new line (`\n`), such as `myvariant1\nmyvariant2`.
+      This input also accepts multiple variants, separated by a line break.
     is_required: false
 - build_type: apk
   opts:

--- a/step/step.go
+++ b/step/step.go
@@ -100,7 +100,7 @@ func (a AndroidBuild) ProcessConfig() (Config, error) {
 	return Config{
 		ProjectLocation: input.ProjectLocation,
 		AppPathPattern:  input.AppPathPattern,
-		Variants:        strings.Split(input.Variant, "\n"),
+		Variants:        strings.Split(input.Variant, `\n`),
 		Module:          input.Module,
 		AppType:         input.BuildType,
 		Arguments:       args,

--- a/step/step.go
+++ b/step/step.go
@@ -100,7 +100,7 @@ func (a AndroidBuild) ProcessConfig() (Config, error) {
 	return Config{
 		ProjectLocation: input.ProjectLocation,
 		AppPathPattern:  input.AppPathPattern,
-		Variants:        strings.Split(input.Variant, `\n`),
+		Variants:        parseVariants(input.Variant),
 		Module:          input.Module,
 		AppType:         input.BuildType,
 		Arguments:       args,
@@ -370,4 +370,18 @@ func (a AndroidBuild) exportArtifacts(artifacts []gradle.Artifact, deployDir str
 		paths = append(paths, filepath.Join(deployDir, artifact.Name))
 	}
 	return paths, nil
+}
+
+// parseVariants returns the list of variants from the raw step input string.
+// The variants are primarily split by linebreaks, but the step used to split by the "\n" substring in the past,
+// so we also handle that for backwards compatibility.
+func parseVariants(input string) []string {
+	var variants []string
+
+	for _, line := range strings.Split(input, "\n") {
+		variantsPerLine := strings.Split(line, `\n`)
+		variants = append(variants, variantsPerLine...)
+	}
+
+	return variants
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Parsing multiple variants in the `variant` input was accidentally changed in #43. This PR adds support for parsing the old way of defining variants, we should not change the existing behavior in a patch version.

### Changes

Parse the variant list by splitting both by line breaks (the literal `\n`) and by `\n\ substrings (this was the old behavior).

### Investigation details

Defining a list of variants by line breaks works in both the workflow editor GUI and in raw YML, like this:

```yml
inputs:
  variant: |-
    fullDevelopDebug
    fullDevelopRelease
  module: app
```

### Decisions

<!-- Please list decisions that were made for this change. -->
