### PR TITLE
feat: wrap gradle with bitrise-build-cache react-native run when active

### DIFF
--- a/step/buildcache/detect.go
+++ b/step/buildcache/detect.go
@@ -7,6 +7,7 @@ package buildcache
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"time"
 
@@ -16,8 +17,12 @@ import (
 const (
 	cliBinary = "bitrise-build-cache"
 
-	lookupTimeout  = 2 * time.Second
-	statusTimeout  = 5 * time.Second
+	statusTimeout = 5 * time.Second
+
+	// OptOutEnv, when set to "0", skips detection entirely and forces the step
+	// to behave as if the CLI were absent. Killswitch for operators if the
+	// wrapper ever ships a regression.
+	OptOutEnv = "BITRISE_BUILD_CACHE_RN_WRAP"
 )
 
 // Detection describes the CLI's reachability and RN-cache activation state on
@@ -32,14 +37,12 @@ type Detection struct {
 // degrades to a zero-value Detection with a warn log — this function must
 // never cause the step to fail.
 func Detect(ctx context.Context, logger log.Logger) Detection {
-	path, err := exec.LookPath(cliBinary)
-	if err != nil {
+	if os.Getenv(OptOutEnv) == "0" {
 		return Detection{}
 	}
 
-	if err := probeCLI(ctx, path); err != nil {
-		logger.Warnf("Bitrise Build Cache CLI found at %s but --version failed: %s. Skipping RN cache wrap.", path, err)
-
+	path, err := exec.LookPath(cliBinary)
+	if err != nil {
 		return Detection{}
 	}
 
@@ -54,18 +57,6 @@ func Detect(ctx context.Context, logger log.Logger) Detection {
 		CLIPath:            path,
 		ReactNativeEnabled: enabled,
 	}
-}
-
-func probeCLI(ctx context.Context, path string) error {
-	ctx, cancel := context.WithTimeout(ctx, lookupTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, path, "--version")
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // queryRNEnabled calls `<cli> status --feature=react-native --quiet`. Exit 0

--- a/step/buildcache/detect.go
+++ b/step/buildcache/detect.go
@@ -1,0 +1,91 @@
+// Package buildcache detects whether the Bitrise Build Cache CLI is installed
+// on this machine and whether the React Native build cache has been activated.
+// The step uses the result to decide whether to wrap its gradle invocation in
+// `bitrise-build-cache react-native run --`.
+package buildcache
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"time"
+
+	"github.com/bitrise-io/go-utils/log"
+)
+
+const (
+	cliBinary = "bitrise-build-cache"
+
+	lookupTimeout  = 2 * time.Second
+	statusTimeout  = 5 * time.Second
+)
+
+// Detection describes the CLI's reachability and RN-cache activation state on
+// this machine. A zero-value Detection means "no wrapping should happen" —
+// either because the CLI is absent, unhealthy, or RN cache isn't activated.
+type Detection struct {
+	CLIPath            string
+	ReactNativeEnabled bool
+}
+
+// Detect probes the CLI on PATH and queries RN-enablement. Any failure
+// degrades to a zero-value Detection with a warn log — this function must
+// never cause the step to fail.
+func Detect(ctx context.Context, logger log.Logger) Detection {
+	path, err := exec.LookPath(cliBinary)
+	if err != nil {
+		return Detection{}
+	}
+
+	if err := probeCLI(ctx, path); err != nil {
+		logger.Warnf("Bitrise Build Cache CLI found at %s but --version failed: %s. Skipping RN cache wrap.", path, err)
+
+		return Detection{}
+	}
+
+	enabled, err := queryRNEnabled(ctx, path)
+	if err != nil {
+		logger.Warnf("Bitrise Build Cache status probe failed (%s). Skipping RN cache wrap.", err)
+
+		return Detection{CLIPath: path}
+	}
+
+	return Detection{
+		CLIPath:            path,
+		ReactNativeEnabled: enabled,
+	}
+}
+
+func probeCLI(ctx context.Context, path string) error {
+	ctx, cancel := context.WithTimeout(ctx, lookupTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "--version")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// queryRNEnabled calls `<cli> status --feature=react-native --quiet`. Exit 0
+// means enabled, exit 1 means disabled. Any other outcome is a probe failure.
+func queryRNEnabled(ctx context.Context, path string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, statusTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "status", "--feature=react-native", "--quiet")
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+	}
+
+	return false, err
+}

--- a/step/buildcache/detect_test.go
+++ b/step/buildcache/detect_test.go
@@ -1,0 +1,119 @@
+package buildcache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetect_NoCLIOnPath(t *testing.T) {
+	// Point PATH at an empty dir so LookPath can't find bitrise-build-cache.
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.Equal(t, Detection{}, got)
+}
+
+func TestDetect_Enabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "stub 1.0.0"
+  exit 0
+fi
+if [ "$1" = "status" ] && [ "$2" = "--feature=react-native" ] && [ "$3" = "--quiet" ]; then
+  exit 0
+fi
+exit 99
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.True(t, got.ReactNativeEnabled)
+	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+}
+
+func TestDetect_Disabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  exit 1
+fi
+exit 99
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.False(t, got.ReactNativeEnabled)
+	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+}
+
+func TestDetect_VersionFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+exit 42
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	// Broken CLI → zero-value (no wrap). CLIPath is left blank so callers
+	// don't accidentally invoke a broken binary later.
+	assert.Equal(t, Detection{}, got)
+}
+
+func TestDetect_StatusFailsUnexpectedly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  exit 7   # neither 0 (enabled) nor 1 (disabled) → probe failure
+fi
+exit 99
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.False(t, got.ReactNativeEnabled)
+	// CLIPath is populated because probeCLI succeeded; only the status probe failed.
+	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+}
+
+func installStub(t *testing.T, dir, script string) {
+	t.Helper()
+	path := filepath.Join(dir, "bitrise-build-cache")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub script: %v", err)
+	}
+}

--- a/step/buildcache/detect_test.go
+++ b/step/buildcache/detect_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -32,12 +33,12 @@ func installStub(t *testing.T, dir string, specs []stubSpec) string {
 			// Use absolute path — tests constrain PATH to the stub dir, so
 			// `sleep` from /bin wouldn't be resolvable otherwise.
 			script += "if [ " + s.match + " ]; then\n"
-			script += "  /bin/sleep " + itoa(s.sleep) + "\n"
-			script += "  exit " + itoa(s.exitCode) + "\n"
+			script += "  /bin/sleep " + strconv.Itoa(s.sleep) + "\n"
+			script += "  exit " + strconv.Itoa(s.exitCode) + "\n"
 			script += "fi\n"
 			continue
 		}
-		script += "if [ " + s.match + " ]; then exit " + itoa(s.exitCode) + "; fi\n"
+		script += "if [ " + s.match + " ]; then exit " + strconv.Itoa(s.exitCode) + "; fi\n"
 	}
 	script += `echo "unexpected args: $*" >&2` + "\n"
 	script += "exit 127\n"
@@ -48,26 +49,6 @@ func installStub(t *testing.T, dir string, specs []stubSpec) string {
 	}
 
 	return path
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var b []byte
-	for n > 0 {
-		b = append([]byte{byte('0' + n%10)}, b...)
-		n /= 10
-	}
-	if neg {
-		b = append([]byte{'-'}, b...)
-	}
-
-	return string(b)
 }
 
 func TestDetect_NoCLIOnPath(t *testing.T) {

--- a/step/buildcache/detect_test.go
+++ b/step/buildcache/detect_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"testing"
 	"time"
 
@@ -13,36 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// stubSpec describes one branch of the shell-script stub. The script matches
-// argv against `match` (a literal shell test expression) and exits with
-// `exitCode`. Any argv that doesn't match a spec prints to stderr and exits
-// 127 — the stub never silently returns a non-0/1 code, so accidental new
-// subprocess calls fail loudly instead of being absorbed as "probe failure".
-type stubSpec struct {
-	match    string // e.g. `"$1" = "status"`
-	exitCode int
-	sleep    int // seconds, 0 = no sleep
-}
-
-func installStub(t *testing.T, dir string, specs []stubSpec) string {
+func installStub(t *testing.T, dir, script string) string {
 	t.Helper()
-
-	script := "#!/bin/sh\n"
-	for _, s := range specs {
-		if s.sleep > 0 {
-			// Use absolute path — tests constrain PATH to the stub dir, so
-			// `sleep` from /bin wouldn't be resolvable otherwise.
-			script += "if [ " + s.match + " ]; then\n"
-			script += "  /bin/sleep " + strconv.Itoa(s.sleep) + "\n"
-			script += "  exit " + strconv.Itoa(s.exitCode) + "\n"
-			script += "fi\n"
-			continue
-		}
-		script += "if [ " + s.match + " ]; then exit " + strconv.Itoa(s.exitCode) + "; fi\n"
-	}
-	script += `echo "unexpected args: $*" >&2` + "\n"
-	script += "exit 127\n"
-
 	path := filepath.Join(dir, "bitrise-build-cache")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write stub script: %v", err)
@@ -66,9 +37,13 @@ func TestDetect_Enabled(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	stubPath := installStub(t, dir, []stubSpec{
-		{match: `"$1" = "status" -a "$2" = "--feature=react-native" -a "$3" = "--quiet"`, exitCode: 0},
-	})
+	stubPath := installStub(t, dir, `#!/bin/sh
+if [ "$1" = "status" ] && [ "$2" = "--feature=react-native" ] && [ "$3" = "--quiet" ]; then
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 127
+`)
 	t.Setenv("PATH", dir)
 
 	got := Detect(context.Background(), log.NewLogger())
@@ -83,9 +58,13 @@ func TestDetect_Disabled(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	stubPath := installStub(t, dir, []stubSpec{
-		{match: `"$1" = "status"`, exitCode: 1},
-	})
+	stubPath := installStub(t, dir, `#!/bin/sh
+if [ "$1" = "status" ]; then
+  exit 1
+fi
+echo "unexpected args: $*" >&2
+exit 127
+`)
 	t.Setenv("PATH", dir)
 
 	got := Detect(context.Background(), log.NewLogger())
@@ -100,10 +79,14 @@ func TestDetect_StatusFailsUnexpectedly(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	stubPath := installStub(t, dir, []stubSpec{
-		// neither 0 (enabled) nor 1 (disabled) → probe failure
-		{match: `"$1" = "status"`, exitCode: 7},
-	})
+	stubPath := installStub(t, dir, `#!/bin/sh
+# neither 0 (enabled) nor 1 (disabled) → probe failure
+if [ "$1" = "status" ]; then
+  exit 7
+fi
+echo "unexpected args: $*" >&2
+exit 127
+`)
 	t.Setenv("PATH", dir)
 
 	got := Detect(context.Background(), log.NewLogger())
@@ -123,10 +106,14 @@ func TestDetect_OldCLIWithoutStatusSubcommand(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	stubPath := installStub(t, dir, []stubSpec{
-		// cobra's "unknown command" exit code is 1
-		{match: `"$1" = "status"`, exitCode: 1},
-	})
+	stubPath := installStub(t, dir, `#!/bin/sh
+# Cobra's "unknown command" exit code is 1.
+if [ "$1" = "status" ]; then
+  exit 1
+fi
+echo "unexpected args: $*" >&2
+exit 127
+`)
 	t.Setenv("PATH", dir)
 
 	got := Detect(context.Background(), log.NewLogger())
@@ -146,10 +133,16 @@ func TestDetect_StatusTimeout(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	stubPath := installStub(t, dir, []stubSpec{
-		// sleep longer than statusTimeout so ctx cancel fires
-		{match: `"$1" = "status"`, exitCode: 0, sleep: 30},
-	})
+	// /bin/sleep absolute path — tests set PATH to stub dir only, so external
+	// sleep wouldn't be resolvable otherwise.
+	stubPath := installStub(t, dir, `#!/bin/sh
+if [ "$1" = "status" ]; then
+  /bin/sleep 30
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 127
+`)
 	t.Setenv("PATH", dir)
 
 	started := time.Now()
@@ -171,9 +164,13 @@ func TestDetect_OptOut(t *testing.T) {
 	dir := t.TempDir()
 	// Stub would report "enabled" if invoked — opt-out env var must short-circuit
 	// before the subprocess spawn.
-	installStub(t, dir, []stubSpec{
-		{match: `"$1" = "status"`, exitCode: 0},
-	})
+	installStub(t, dir, `#!/bin/sh
+if [ "$1" = "status" ]; then
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 127
+`)
 	t.Setenv("PATH", dir)
 	t.Setenv(OptOutEnv, "0")
 

--- a/step/buildcache/detect_test.go
+++ b/step/buildcache/detect_test.go
@@ -6,13 +6,71 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/stretchr/testify/assert"
 )
 
+// stubSpec describes one branch of the shell-script stub. The script matches
+// argv against `match` (a literal shell test expression) and exits with
+// `exitCode`. Any argv that doesn't match a spec prints to stderr and exits
+// 127 — the stub never silently returns a non-0/1 code, so accidental new
+// subprocess calls fail loudly instead of being absorbed as "probe failure".
+type stubSpec struct {
+	match    string // e.g. `"$1" = "status"`
+	exitCode int
+	sleep    int // seconds, 0 = no sleep
+}
+
+func installStub(t *testing.T, dir string, specs []stubSpec) string {
+	t.Helper()
+
+	script := "#!/bin/sh\n"
+	for _, s := range specs {
+		if s.sleep > 0 {
+			// Use absolute path — tests constrain PATH to the stub dir, so
+			// `sleep` from /bin wouldn't be resolvable otherwise.
+			script += "if [ " + s.match + " ]; then\n"
+			script += "  /bin/sleep " + itoa(s.sleep) + "\n"
+			script += "  exit " + itoa(s.exitCode) + "\n"
+			script += "fi\n"
+			continue
+		}
+		script += "if [ " + s.match + " ]; then exit " + itoa(s.exitCode) + "; fi\n"
+	}
+	script += `echo "unexpected args: $*" >&2` + "\n"
+	script += "exit 127\n"
+
+	path := filepath.Join(dir, "bitrise-build-cache")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub script: %v", err)
+	}
+
+	return path
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+
+	return string(b)
+}
+
 func TestDetect_NoCLIOnPath(t *testing.T) {
-	// Point PATH at an empty dir so LookPath can't find bitrise-build-cache.
 	emptyDir := t.TempDir()
 	t.Setenv("PATH", emptyDir)
 
@@ -27,22 +85,15 @@ func TestDetect_Enabled(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	installStub(t, dir, `#!/bin/sh
-if [ "$1" = "--version" ]; then
-  echo "stub 1.0.0"
-  exit 0
-fi
-if [ "$1" = "status" ] && [ "$2" = "--feature=react-native" ] && [ "$3" = "--quiet" ]; then
-  exit 0
-fi
-exit 99
-`)
+	stubPath := installStub(t, dir, []stubSpec{
+		{match: `"$1" = "status" -a "$2" = "--feature=react-native" -a "$3" = "--quiet"`, exitCode: 0},
+	})
 	t.Setenv("PATH", dir)
 
 	got := Detect(context.Background(), log.NewLogger())
 
 	assert.True(t, got.ReactNativeEnabled)
-	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+	assert.Equal(t, stubPath, got.CLIPath)
 }
 
 func TestDetect_Disabled(t *testing.T) {
@@ -51,39 +102,15 @@ func TestDetect_Disabled(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	installStub(t, dir, `#!/bin/sh
-if [ "$1" = "--version" ]; then
-  exit 0
-fi
-if [ "$1" = "status" ]; then
-  exit 1
-fi
-exit 99
-`)
+	stubPath := installStub(t, dir, []stubSpec{
+		{match: `"$1" = "status"`, exitCode: 1},
+	})
 	t.Setenv("PATH", dir)
 
 	got := Detect(context.Background(), log.NewLogger())
 
 	assert.False(t, got.ReactNativeEnabled)
-	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
-}
-
-func TestDetect_VersionFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("shell-script stub isn't portable to windows")
-	}
-
-	dir := t.TempDir()
-	installStub(t, dir, `#!/bin/sh
-exit 42
-`)
-	t.Setenv("PATH", dir)
-
-	got := Detect(context.Background(), log.NewLogger())
-
-	// Broken CLI → zero-value (no wrap). CLIPath is left blank so callers
-	// don't accidentally invoke a broken binary later.
-	assert.Equal(t, Detection{}, got)
+	assert.Equal(t, stubPath, got.CLIPath)
 }
 
 func TestDetect_StatusFailsUnexpectedly(t *testing.T) {
@@ -92,28 +119,84 @@ func TestDetect_StatusFailsUnexpectedly(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	installStub(t, dir, `#!/bin/sh
-if [ "$1" = "--version" ]; then
-  exit 0
-fi
-if [ "$1" = "status" ]; then
-  exit 7   # neither 0 (enabled) nor 1 (disabled) → probe failure
-fi
-exit 99
-`)
+	stubPath := installStub(t, dir, []stubSpec{
+		// neither 0 (enabled) nor 1 (disabled) → probe failure
+		{match: `"$1" = "status"`, exitCode: 7},
+	})
 	t.Setenv("PATH", dir)
 
 	got := Detect(context.Background(), log.NewLogger())
 
 	assert.False(t, got.ReactNativeEnabled)
-	// CLIPath is populated because probeCLI succeeded; only the status probe failed.
-	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+	assert.Equal(t, stubPath, got.CLIPath)
 }
 
-func installStub(t *testing.T, dir, script string) {
-	t.Helper()
-	path := filepath.Join(dir, "bitrise-build-cache")
-	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
-		t.Fatalf("write stub script: %v", err)
+// TestDetect_OldCLIWithoutStatusSubcommand simulates a user running an older
+// CLI binary that predates the `status` subcommand. Cobra exits 1 on unknown
+// command, which queryRNEnabled reads as "disabled" — correct safe fallback,
+// but worth asserting since it's every user's state during the release window
+// between CLI merge and step rollout.
+func TestDetect_OldCLIWithoutStatusSubcommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
 	}
+
+	dir := t.TempDir()
+	stubPath := installStub(t, dir, []stubSpec{
+		// cobra's "unknown command" exit code is 1
+		{match: `"$1" = "status"`, exitCode: 1},
+	})
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.False(t, got.ReactNativeEnabled)
+	assert.Equal(t, stubPath, got.CLIPath)
+}
+
+// TestDetect_StatusTimeout asserts that a hung CLI does not hang the step.
+// This is the most important invariant of this module.
+func TestDetect_StatusTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+	if testing.Short() {
+		t.Skip("timeout test is slow")
+	}
+
+	dir := t.TempDir()
+	stubPath := installStub(t, dir, []stubSpec{
+		// sleep longer than statusTimeout so ctx cancel fires
+		{match: `"$1" = "status"`, exitCode: 0, sleep: 30},
+	})
+	t.Setenv("PATH", dir)
+
+	started := time.Now()
+	got := Detect(context.Background(), log.NewLogger())
+	elapsed := time.Since(started)
+
+	assert.False(t, got.ReactNativeEnabled)
+	assert.Equal(t, stubPath, got.CLIPath)
+	// Allow generous headroom over statusTimeout for CI jitter, but prove we
+	// didn't wait on the full sleep.
+	assert.Less(t, elapsed, 15*time.Second, "Detect must return within statusTimeout + slack")
+}
+
+func TestDetect_OptOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	// Stub would report "enabled" if invoked — opt-out env var must short-circuit
+	// before the subprocess spawn.
+	installStub(t, dir, []stubSpec{
+		{match: `"$1" = "status"`, exitCode: 0},
+	})
+	t.Setenv("PATH", dir)
+	t.Setenv(OptOutEnv, "0")
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.Equal(t, Detection{}, got)
 }

--- a/step/step.go
+++ b/step/step.go
@@ -58,6 +58,7 @@ type AndroidBuild struct {
 	inputParser stepconf.InputParser
 	logger      log.Logger
 	cmdFactory  command.Factory
+	detect      func(context.Context, log.Logger) buildcache.Detection
 }
 
 // GradleProjectWrapper ...
@@ -81,7 +82,12 @@ const (
 
 // NewAndroidBuild ...
 func NewAndroidBuild(inputParser stepconf.InputParser, logger log.Logger, cmdFactory command.Factory) *AndroidBuild {
-	return &AndroidBuild{inputParser: inputParser, logger: logger, cmdFactory: cmdFactory}
+	return &AndroidBuild{
+		inputParser: inputParser,
+		logger:      logger,
+		cmdFactory:  cmdFactory,
+		detect:      buildcache.Detect,
+	}
 }
 
 // ProcessConfig ...
@@ -122,7 +128,7 @@ func (a AndroidBuild) Run(cfg Config) (Result, error) {
 
 	started := time.Now()
 
-	if err := a.executeGradleBuild(cfg); err != nil {
+	if err := a.executeGradleBuild(context.Background(), cfg); err != nil {
 		return Result{}, err
 	}
 
@@ -288,7 +294,7 @@ func (a AndroidBuild) getArtifacts(gradleProject GradleProjectWrapper, started t
 	return
 }
 
-func (a AndroidBuild) executeGradleBuild(cfg Config) error {
+func (a AndroidBuild) executeGradleBuild(ctx context.Context, cfg Config) error {
 	a.logger.Infof("Run build:")
 
 	var tasks []string
@@ -312,7 +318,7 @@ func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 	}
 	gradlewPath := filepath.Join(absPath, "gradlew")
 
-	cmd := a.buildGradleCommand(gradlewPath, cmdArgs, &cmdOpts)
+	cmd := a.buildGradleCommand(ctx, gradlewPath, cmdArgs, &cmdOpts)
 
 	a.logger.Println()
 	a.logger.Donef("$ " + cmd.PrintableCommandArgs())
@@ -330,9 +336,11 @@ func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 // CLI is installed and React Native build cache is active on this machine.
 // When no wrap is needed (CLI absent, probe failed, or RN cache not activated),
 // the original `gradlew ...` command is returned unchanged.
-func (a AndroidBuild) buildGradleCommand(gradlewPath string, cmdArgs []string, cmdOpts *command.Opts) command.Command {
-	det := buildcache.Detect(context.Background(), a.logger)
+func (a AndroidBuild) buildGradleCommand(ctx context.Context, gradlewPath string, cmdArgs []string, cmdOpts *command.Opts) command.Command {
+	det := a.detect(ctx, a.logger)
 	if !det.ReactNativeEnabled {
+		a.logger.Debugf("Bitrise Build Cache: no RN wrap (cli=%v enabled=%v)", det.CLIPath != "", det.ReactNativeEnabled)
+
 		return a.cmdFactory.Create(gradlewPath, cmdArgs, cmdOpts)
 	}
 

--- a/step/step.go
+++ b/step/step.go
@@ -1,6 +1,7 @@
 package step
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-steplib/bitrise-step-android-build/step/buildcache"
 	"github.com/kballard/go-shellquote"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -308,7 +310,9 @@ func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 	if err != nil {
 		return err
 	}
-	cmd := a.cmdFactory.Create(filepath.Join(absPath, "gradlew"), cmdArgs, &cmdOpts)
+	gradlewPath := filepath.Join(absPath, "gradlew")
+
+	cmd := a.buildGradleCommand(gradlewPath, cmdArgs, &cmdOpts)
 
 	a.logger.Println()
 	a.logger.Donef("$ " + cmd.PrintableCommandArgs())
@@ -319,6 +323,24 @@ func (a AndroidBuild) executeGradleBuild(cfg Config) error {
 	}
 
 	return nil
+}
+
+// buildGradleCommand constructs the gradle invocation, transparently wrapping
+// it in `bitrise-build-cache react-native run --` when the Bitrise Build Cache
+// CLI is installed and React Native build cache is active on this machine.
+// When no wrap is needed (CLI absent, probe failed, or RN cache not activated),
+// the original `gradlew ...` command is returned unchanged.
+func (a AndroidBuild) buildGradleCommand(gradlewPath string, cmdArgs []string, cmdOpts *command.Opts) command.Command {
+	det := buildcache.Detect(context.Background(), a.logger)
+	if !det.ReactNativeEnabled {
+		return a.cmdFactory.Create(gradlewPath, cmdArgs, cmdOpts)
+	}
+
+	a.logger.Infof("Bitrise Build Cache: React Native cache active — wrapping gradle with %s", det.CLIPath)
+
+	wrapped := append([]string{"react-native", "run", "--", gradlewPath}, cmdArgs...)
+
+	return a.cmdFactory.Create(det.CLIPath, wrapped, cmdOpts)
 }
 
 func (a AndroidBuild) printAppSearchInfo(appArtifacts []gradle.Artifact, appPathPatterns []string) {

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -1,10 +1,8 @@
 package step
 
 import (
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,6 +11,7 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/env"
 	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-steplib/bitrise-step-android-build/step/buildcache"
 	"github.com/bitrise-steplib/bitrise-step-android-build/step/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -77,46 +76,47 @@ func createStep() AndroidBuild {
 		inputParser: stepconf.NewInputParser(envRepository),
 		logger:      log.NewLogger(),
 		cmdFactory:  command.NewFactory(envRepository),
+		detect: func(context.Context, log.Logger) buildcache.Detection {
+			return buildcache.Detection{}
+		},
 	}
 }
 
 func Test_buildGradleCommand_NoWrapWhenCLIMissing(t *testing.T) {
-	// PATH pointing at empty dir → no CLI found → no wrap.
-	t.Setenv("PATH", t.TempDir())
-
 	step := createStep()
-	cmd := step.buildGradleCommand("/tmp/proj/gradlew", []string{"assembleDebug"}, &command.Opts{})
+	step.detect = func(context.Context, log.Logger) buildcache.Detection {
+		return buildcache.Detection{}
+	}
 
-	printed := cmd.PrintableCommandArgs()
-	assert.Contains(t, printed, "gradlew")
-	assert.NotContains(t, printed, "bitrise-build-cache")
+	cmd := step.buildGradleCommand(context.Background(), "/tmp/proj/gradlew", []string{"assembleDebug"}, &command.Opts{})
+
+	assert.Equal(t, `/tmp/proj/gradlew "assembleDebug"`, cmd.PrintableCommandArgs())
+}
+
+func Test_buildGradleCommand_NoWrapWhenDetected_NotEnabled(t *testing.T) {
+	// CLI present but RN cache not active → still no wrap.
+	step := createStep()
+	step.detect = func(context.Context, log.Logger) buildcache.Detection {
+		return buildcache.Detection{CLIPath: "/usr/local/bin/bitrise-build-cache"}
+	}
+
+	cmd := step.buildGradleCommand(context.Background(), "/tmp/proj/gradlew", []string{"assembleDebug"}, &command.Opts{})
+
+	assert.Equal(t, `/tmp/proj/gradlew "assembleDebug"`, cmd.PrintableCommandArgs())
 }
 
 func Test_buildGradleCommand_WrapsWhenRNCacheEnabled(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("shell-script stub isn't portable to windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "bitrise-build-cache")
-	err := os.WriteFile(stub, []byte(`#!/bin/sh
-# --version → exit 0; status --feature=react-native --quiet → exit 0 (enabled)
-[ "$1" = "--version" ] && exit 0
-[ "$1" = "status" ] && exit 0
-exit 99
-`), 0o755)
-	assert.NoError(t, err)
-	t.Setenv("PATH", dir)
+	cliPath := "/usr/local/bin/bitrise-build-cache"
 
 	step := createStep()
-	cmd := step.buildGradleCommand("/tmp/proj/gradlew", []string{"assembleDebug"}, &command.Opts{})
+	step.detect = func(context.Context, log.Logger) buildcache.Detection {
+		return buildcache.Detection{CLIPath: cliPath, ReactNativeEnabled: true}
+	}
 
-	printed := cmd.PrintableCommandArgs()
-	assert.Contains(t, printed, "bitrise-build-cache")
-	assert.Contains(t, printed, "react-native")
-	assert.Contains(t, printed, "run")
-	assert.Contains(t, printed, "gradlew")
-	assert.True(t, strings.Contains(printed, "assembleDebug"), "gradle args preserved after wrap")
+	cmd := step.buildGradleCommand(context.Background(), "/tmp/proj/gradlew", []string{"assembleDebug", "--info"}, &command.Opts{})
+
+	expected := fmt.Sprintf(`%s "react-native" "run" "--" "/tmp/proj/gradlew" "assembleDebug" "--info"`, cliPath)
+	assert.Equal(t, expected, cmd.PrintableCommandArgs())
 }
 
 func Test_gradleTaskName(t *testing.T) {

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -1,6 +1,10 @@
 package step
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,6 +78,45 @@ func createStep() AndroidBuild {
 		logger:      log.NewLogger(),
 		cmdFactory:  command.NewFactory(envRepository),
 	}
+}
+
+func Test_buildGradleCommand_NoWrapWhenCLIMissing(t *testing.T) {
+	// PATH pointing at empty dir → no CLI found → no wrap.
+	t.Setenv("PATH", t.TempDir())
+
+	step := createStep()
+	cmd := step.buildGradleCommand("/tmp/proj/gradlew", []string{"assembleDebug"}, &command.Opts{})
+
+	printed := cmd.PrintableCommandArgs()
+	assert.Contains(t, printed, "gradlew")
+	assert.NotContains(t, printed, "bitrise-build-cache")
+}
+
+func Test_buildGradleCommand_WrapsWhenRNCacheEnabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "bitrise-build-cache")
+	err := os.WriteFile(stub, []byte(`#!/bin/sh
+# --version → exit 0; status --feature=react-native --quiet → exit 0 (enabled)
+[ "$1" = "--version" ] && exit 0
+[ "$1" = "status" ] && exit 0
+exit 99
+`), 0o755)
+	assert.NoError(t, err)
+	t.Setenv("PATH", dir)
+
+	step := createStep()
+	cmd := step.buildGradleCommand("/tmp/proj/gradlew", []string{"assembleDebug"}, &command.Opts{})
+
+	printed := cmd.PrintableCommandArgs()
+	assert.Contains(t, printed, "bitrise-build-cache")
+	assert.Contains(t, printed, "react-native")
+	assert.Contains(t, printed, "run")
+	assert.Contains(t, printed, "gradlew")
+	assert.True(t, strings.Contains(printed, "assembleDebug"), "gradle args preserved after wrap")
 }
 
 func Test_gradleTaskName(t *testing.T) {


### PR DESCRIPTION
## Summary

When the Bitrise Build Cache CLI is installed and React Native build cache has been activated on this machine, the step now transparently wraps its gradle invocation in \`bitrise-build-cache react-native run --\`.

Users do not need to add a new step input. \`bitrise-build-cache react-native activate\` is the single point of control — the step auto-detects it and wraps accordingly.

## How it works

\`step/buildcache.Detect\` probes PATH for \`bitrise-build-cache\`, then runs \`<cli> status --feature=react-native --quiet\`:
- exit 0 → RN cache active → wrap
- exit 1 → RN cache inactive → no wrap
- missing CLI / broken CLI / probe failure → **no wrap**, step behaves identically to before

Wrap scope is limited to the build exec (not the whole step), so analytics continue to reflect build time only.

Depends on [bitrise-io/bitrise-build-cache-cli#277](https://github.com/bitrise-io/bitrise-build-cache-cli/pull/277), which adds the \`status\` command this PR probes.

## Test plan

- [x] Unit tests pass (\`go test ./...\`)
  - \`TestDetect_*\` covers CLI-missing / enabled / disabled / probe-failure matrix with a shell-script stub
  - \`Test_buildGradleCommand_NoWrapWhenCLIMissing\` → unchanged \`gradlew\` path
  - \`Test_buildGradleCommand_WrapsWhenRNCacheEnabled\` → asserts argv is \`bitrise-build-cache react-native run -- gradlew <args>\`
- [ ] End-to-end on an RN sample project:
  - before \`react-native activate\`: step logs plain \`\$ .../gradlew ...\`
  - after \`react-native activate\`: step logs \`\$ .../bitrise-build-cache react-native run -- .../gradlew ...\`
  - with CLI uninstalled: step output identical to pre-change baseline
- [ ] Depends on CLI PR being merged + released (PATH-based probe → no version pin here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)