### PR TITLE
Migrate to shared steps-check workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Builds your Android project with Gradle.
 <details>
 <summary>Description</summary>
 
-
 The Step builds your Android project on Bitrise with Gradle commands: it installs all dependencies that are listed in the project's `build.gradle` file, and builds and exports either an APK or an AAB.
 Once the file is exported, it is available for other Steps in your Workflow.
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,6 +1,11 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+include:
+- repository: steps-check
+  branch: master
+  path: steps.bitrise.yml
+
 workflows:
   sample:
     steps:
@@ -16,9 +21,7 @@ workflows:
         - variant: debug
         - app_type: aab
 
-  check:
-    steps:
-    - git::https://github.com/bitrise-steplib/steps-check.git: { }
+  # check: included from steps-check/steps.bitrise.yml
 
   e2e:
     steps:

--- a/step.yml
+++ b/step.yml
@@ -1,7 +1,6 @@
 title: Android Build
 summary: Builds your Android project with Gradle.
 description: |-
-
   The Step builds your Android project on Bitrise with Gradle commands: it installs all dependencies that are listed in the project's `build.gradle` file, and builds and exports either an APK or an AAB.
   Once the file is exported, it is available for other Steps in your Workflow.
 


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context

Switch from the temporary `bitrise-includes` branch pin to the stable `master` branch of `steps-check`, completing the migration to the shared check workflow.

### Changes

- Update `include` branch from `bitrise-includes` to `master` (the branch is now stable/released)
- Remove the local `check` workflow definition (now provided by the include)
- yamlfmt auto-formatting: remove stray blank lines in `step.yml` and `README.md`

### Investigation details

The `include` block was already present but pointing to `bitrise-includes` with a `# TODO: main branch` comment. This PR resolves that TODO now that the shared workflow is on `master`.

### Decisions

- Kept a comment in place of the removed `check` workflow (`# check: included from steps-check/steps.bitrise.yml`) so it's clear the workflow still exists, just sourced from the include.