### PR TITLE
feat: export BITRISE_MAPPING_PATH_LIST (SSW-3065)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Build a release AAB:
 | `BITRISE_APK_PATH_LIST` | This output will include the paths of the generated APKs after filtering based on the filter inputs. The paths are separated with `\|` character, for example, `app-armeabi-v7a-debug.apk\|app-mips-debug.apk\|app-x86-debug.apk` |
 | `BITRISE_AAB_PATH` | This output will include the path of the generated AAB after filtering based on the filter inputs. If the build generates more than one AAB which fulfills the filter inputs, this output will contain the last one's path. |
 | `BITRISE_AAB_PATH_LIST` | This output will include the paths of the generated AABs after filtering based on the filter inputs. The paths are separated with `\|` character, for example, `app--debug.aab\|app-mips-debug.aab` |
-| `BITRISE_MAPPING_PATH` | This output will include the path of the generated mapping.txt. If more than one mapping.txt exist in the project, this output will contain the last one's path. |
+| `BITRISE_MAPPING_PATH` | This output will include the path of the generated mapping.txt.  If more than one mapping.txt exist in the project, this output will contain the last one's path. When the build produces more than one mapping file, use `BITRISE_MAPPING_PATH_LIST` instead: it contains all of them. |
+| `BITRISE_MAPPING_PATH_LIST` | This output will include the paths of the generated mapping files. The paths are separated with `\|` character, for example, `app-mapping.txt\|another_app-mapping.txt`  The order of the list carries no meaning, and the file names do not identify which build variant a mapping belongs to. Consumers should pair a mapping with its artifact by reading the `# pg_map_id:` header of the mapping file and matching it against the `pg-map-id` of the R8 marker embedded in the artifact, rather than relying on order or on the file name. |
 </details>
 
 ## 🙋 Contributing

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -34,6 +34,10 @@ workflows:
     - EXPECTED_APK: another_app-full-release-unsigned.apk
     - EXPECTED_APK_PATH_LIST: $BITRISE_DEPLOY_DIR/another_app-demo-release-unsigned.apk|$BITRISE_DEPLOY_DIR/another_app-full-release-unsigned.apk
     - EXPECTED_MAPPING: another_app-mapping.txt
+    # demo and full are both built, so both variants publish a mapping.txt; the
+    # second one is collision-renamed in the deploy dir and is only reachable
+    # through BITRISE_MAPPING_PATH_LIST.
+    - EXPECTED_MAPPING_COUNT: "2"
     - JDK_VERSION: "17"
     before_run:
     - _setup
@@ -247,3 +251,35 @@ workflows:
               ls -la $BITRISE_DEPLOY_DIR
               exit 1
             fi
+
+            echo "BITRISE_MAPPING_PATH_LIST: $BITRISE_MAPPING_PATH_LIST"
+
+            if [ -z "$BITRISE_MAPPING_PATH_LIST" ] ; then echo "BITRISE_MAPPING_PATH_LIST env is empty" ; exit 1 ; fi ;
+
+            # Every mapping the build published must be reachable, not just the last
+            # one. This is what lets a consumer pair each artifact with its own mapping
+            # by pg_map_id; BITRISE_MAPPING_PATH alone cannot express two variants.
+            expected_count="${EXPECTED_MAPPING_COUNT:-1}"
+            listed_files=$(printf '%s' "$BITRISE_MAPPING_PATH_LIST" | tr '|' '\n' | grep . | sort)
+            listed_count=$(printf '%s' "$listed_files" | grep -c . || true)
+            if [ "$listed_count" -ne "$expected_count" ] ; then
+              echo "Expected $expected_count path(s) in BITRISE_MAPPING_PATH_LIST, got $listed_count"
+              exit 1
+            fi
+
+            # Herestring, not a pipe: a piped `while read` runs in a subshell where
+            # `exit 1` would not fail this script.
+            while read -r file ; do
+              if [ ! -f "$file" ] ; then
+                echo "Listed mapping file does not exist: '$file'"
+                ls -la $BITRISE_DEPLOY_DIR
+                exit 1
+              fi
+              if ! grep -q "^# pg_map_id: " "$file" ; then
+                echo "Listed mapping has no pg_map_id header, pairing would be impossible: $file"
+                head -5 "$file"
+                exit 1
+              fi
+            done <<< "$listed_files"
+
+            echo "OK: all $listed_count published mapping file(s) are listed and carry a pg_map_id"

--- a/step.yml
+++ b/step.yml
@@ -174,4 +174,19 @@ outputs:
     summary: Path of the generated (and copied) mapping.txt.
     description: |-
       This output will include the path of the generated mapping.txt.
+
       If more than one mapping.txt exist in the project, this output will contain the last one's path.
+      When the build produces more than one mapping file, use `BITRISE_MAPPING_PATH_LIST` instead: it
+      contains all of them.
+- BITRISE_MAPPING_PATH_LIST:
+  opts:
+    title: List of the generated mapping.txt file paths
+    summary: List of the generated (and copied) mapping.txt file paths.
+    description: |-
+      This output will include the paths of the generated mapping files.
+      The paths are separated with `|` character, for example, `app-mapping.txt|another_app-mapping.txt`
+
+      The order of the list carries no meaning, and the file names do not identify which build variant a
+      mapping belongs to. Consumers should pair a mapping with its artifact by reading the `# pg_map_id:`
+      header of the mapping file and matching it against the `pg-map-id` of the R8 marker embedded in the
+      artifact, rather than relying on order or on the file name.

--- a/step/step.go
+++ b/step/step.go
@@ -78,8 +78,9 @@ const (
 	aabEnvKey     = "BITRISE_AAB_PATH"
 	aabListEnvKey = "BITRISE_AAB_PATH_LIST"
 
-	mappingFileEnvKey  = "BITRISE_MAPPING_PATH"
-	mappingFilePattern = "*build/*/mapping.txt"
+	mappingFileEnvKey     = "BITRISE_MAPPING_PATH"
+	mappingFileListEnvKey = "BITRISE_MAPPING_PATH_LIST"
+	mappingFilePattern    = "*build/*/mapping.txt"
 )
 
 // NewAndroidBuild ...
@@ -243,6 +244,12 @@ func (a AndroidBuild) Export(result Result, deployDir string) error {
 		return fmt.Errorf("failed to export environment variable: %s", mappingFileEnvKey)
 	}
 	a.logger.Printf("  Env    [ $%s = $BITRISE_DEPLOY_DIR/%s ]", mappingFileEnvKey, filepath.Base(lastExportedArtifact))
+
+	mappingList := strings.Join(exportedArtifactPaths, "|")
+	if err := a.exporter.ExportOutput(mappingFileListEnvKey, mappingList); err != nil {
+		return fmt.Errorf("failed to export environment variable: %s", mappingFileListEnvKey)
+	}
+	a.logger.Printf("  Env    [ $%s = %s ]", mappingFileListEnvKey, mappingList)
 
 	return nil
 }


### PR DESCRIPTION
### Version
Requires a *MINOR* [version update](https://semver.org/) — one new output, no behaviour change to existing ones.

### Context

Part of [SSW-3065](https://bitrise.atlassian.net/browse/SSW-3065). Same change as bitrise-steplib/steps-gradle-runner#135, for the other Android build Step.

The Step already copied every mapping file it found into the deploy directory but exported only the last one's path, so a multi-module or multi-flavour build published several mapping files and made one of them addressable. `BITRISE_MAPPING_PATH_LIST` makes all of them reachable.

Independent of the gradle-runner PR — no stacking, targets `master`.

### Changes

- `step/step.go`: add `mappingFileListEnvKey` and export the joined list after the singular one.
- `BITRISE_MAPPING_PATH` keeps its last-one-wins value, so nothing that reads it today changes.
- `step.yml`: declare the new output, and state that the order carries no meaning and the names do not identify a variant, with a pointer to how consumers should pair instead.
- `e2e/bitrise.yml`: `_check_mapping` now asserts that every published mapping is listed, that each listed path exists, and that each carries the `# pg_map_id:` header. Gated on a new `EXPECTED_MAPPING_COUNT`, set to `2` for `test_multiple_variants` and defaulting to `1` so the single-variant workflows are unaffected.
- `README.md` regenerated.

### Investigation details

This Step is already a step ahead of gradle-runner here: it collects mapping files with `includeModuleInName`, so the exported name is `another_app-mapping.txt` and the **module** survives the copy. The flavour and build type do not, and a second variant of the same module still collides by name and gets timestamp-renamed.

`test_multiple_variants` builds `demo` and `full` of `another_app`, so it already publishes two mapping files — but `EXPECTED_MAPPING` asserted a single name, and the second file was unreachable. That workflow is exactly the case the new output exists for, so the assertion was extended rather than a new fixture added.

### Decisions

**No variant labelling here either.** See the investigation details on bitrise-steplib/steps-gradle-runner#135: the variant is only cleanly derivable for APKs, and `output-metadata.json` is not generated for AABs at all. Consumers pair by content instead, matching the mapping's `# pg_map_id:` header against the `pg-map-id` of the R8 marker in the artifact — which is exact and survives both the collision rename and re-signing.

**Reused the existing e2e fixture** rather than committing binary artifacts: `bitrise-io/android-multiple-test-results-sample` already builds multiple minified variants.

Agreed on [this thread](https://bitfall.slack.com/archives/C08JQ0PJNF8/p1787156391071959?thread_ts=1787124398.230389&cid=C08JQ0PJNF8). Consumer side: bitrise-steplib/steps-google-play-deploy#192.


[SSW-3065]: https://bitrise.atlassian.net/browse/SSW-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ