### PR TITLE
fix: don't overwrite a deploy artifact on a same-second name collision

### DIFF
--- a/step/export_test.go
+++ b/step/export_test.go
@@ -1,0 +1,42 @@
+package step
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_freeDeployName_SameSecondCollision(t *testing.T) {
+	deployDir := t.TempDir()
+	build := AndroidBuild{logger: log.NewLogger(), pathChecker: pathutil.NewPathChecker()}
+
+	// nothing there yet: the artifact keeps its own name
+	first, err := build.freeDeployName(deployDir, "mapping.txt")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "mapping.txt", first)
+	assert.NoError(t, os.WriteFile(filepath.Join(deployDir, first), []byte("demoRelease"), 0600))
+
+	second, err := build.freeDeployName(deployDir, "mapping.txt")
+	assert.NoError(t, err)
+	assert.NotEqual(t, first, second)
+	assert.NoError(t, os.WriteFile(filepath.Join(deployDir, second), []byte("paidRelease"), 0600))
+
+	// the third export lands in the same second as the second one
+	third, err := build.freeDeployName(deployDir, "mapping.txt")
+	assert.NoError(t, err)
+	assert.NotEqual(t, second, third, "a same-second collision must not reuse the taken name")
+	assert.NoError(t, os.WriteFile(filepath.Join(deployDir, third), []byte("fullRelease"), 0600))
+
+	// each variant's content survives under its own name
+	for name, want := range map[string]string{first: "demoRelease", second: "paidRelease", third: "fullRelease"} {
+		content, err := os.ReadFile(filepath.Join(deployDir, name))
+		assert.NoError(t, err)
+		assert.Equal(t, want, string(content), "%s should still hold its own variant's file", name)
+	}
+}

--- a/step/step.go
+++ b/step/step.go
@@ -80,6 +80,10 @@ const (
 
 	mappingFileEnvKey  = "BITRISE_MAPPING_PATH"
 	mappingFilePattern = "*build/*/mapping.txt"
+
+	// how many suffixed names freeDeployName tries before it settles for
+	// overwriting — high enough for any real per-variant fan-out
+	maxDeployNameAttempts = 100
 )
 
 // NewAndroidBuild ...
@@ -194,7 +198,7 @@ func (a AndroidBuild) Export(result Result, deployDir string) error {
 		envKey = aabEnvKey
 	}
 	if err := a.exporter.ExportOutput(envKey, lastExportedArtifact); err != nil {
-		return fmt.Errorf("failed to export environment variable: %s", envKey)
+		return fmt.Errorf("failed to export environment variable %s: %w", envKey, err)
 	}
 	a.logger.Println()
 	a.logger.Printf("  Env    [ $%s = $BITRISE_DEPLOY_DIR/%s ]", envKey, filepath.Base(lastExportedArtifact))
@@ -212,7 +216,7 @@ func (a AndroidBuild) Export(result Result, deployDir string) error {
 		envKey = aabListEnvKey
 	}
 	if err := a.exporter.ExportOutput(envKey, strings.Join(exportedArtifactPaths, "|")); err != nil {
-		return fmt.Errorf("failed to export environment variable: %s", envKey)
+		return fmt.Errorf("failed to export environment variable %s: %w", envKey, err)
 	}
 	a.logger.Printf("  Env    [ $%s = %s ]", envKey, paths)
 
@@ -240,7 +244,7 @@ func (a AndroidBuild) Export(result Result, deployDir string) error {
 
 	a.logger.Println()
 	if err := a.exporter.ExportOutput(mappingFileEnvKey, lastExportedArtifact); err != nil {
-		return fmt.Errorf("failed to export environment variable: %s", mappingFileEnvKey)
+		return fmt.Errorf("failed to export environment variable %s: %w", mappingFileEnvKey, err)
 	}
 	a.logger.Printf("  Env    [ $%s = $BITRISE_DEPLOY_DIR/%s ]", mappingFileEnvKey, filepath.Base(lastExportedArtifact))
 
@@ -372,22 +376,56 @@ func (a AndroidBuild) printAppSearchInfo(appArtifacts []gradle.Artifact, appPath
 	a.logger.Println()
 }
 
+// freeDeployName returns a name that no file in the deploy dir holds yet.
+// Artifacts of different variants share a base name (every module's mapping
+// file is mapping.txt) and the deploy dir is flat, so a colliding name gets a
+// timestamp. That timestamp only has second resolution, so a run exporting two
+// same-named files within the same second needs a further suffix — without it
+// the second copy silently overwrote the first, and both variants' outputs
+// pointed at a file that belongs to only one of them.
+func (a AndroidBuild) freeDeployName(deployDir, name string) (string, error) {
+	taken, err := a.pathChecker.IsPathExists(filepath.Join(deployDir, name))
+	if err != nil {
+		return "", err
+	}
+	if !taken {
+		return name, nil
+	}
+
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(filepath.Base(name), ext)
+	timestamp := time.Now().Format("20060102150405")
+
+	candidate := fmt.Sprintf("%s-%s%s", base, timestamp, ext)
+	for attempt := 2; ; attempt++ {
+		taken, err := a.pathChecker.IsPathExists(filepath.Join(deployDir, candidate))
+		if err != nil {
+			return "", err
+		}
+		if !taken {
+			return candidate, nil
+		}
+		if attempt > maxDeployNameAttempts {
+			// keep the last candidate: overwriting one file is a better
+			// outcome than failing a build that otherwise succeeded
+			a.logger.Warnf("Gave up finding a free name for %s in the deploy dir after %d attempts, %s will be overwritten", name, maxDeployNameAttempts, candidate)
+
+			return candidate, nil
+		}
+		candidate = fmt.Sprintf("%s-%s-%d%s", base, timestamp, attempt, ext)
+	}
+}
+
 func (a AndroidBuild) exportArtifacts(artifacts []gradle.Artifact, deployDir string) ([]string, error) {
 	var paths []string
 	for _, artifact := range artifacts {
-		exists, err := a.pathChecker.IsPathExists(filepath.Join(deployDir, artifact.Name))
+		artifactName := filepath.Base(artifact.Path)
+
+		deployName, err := a.freeDeployName(deployDir, artifact.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check path, error: %v", err)
 		}
-
-		artifactName := filepath.Base(artifact.Path)
-
-		if exists {
-			timestamp := time.Now().Format("20060102150405")
-			ext := filepath.Ext(artifact.Name)
-			name := strings.TrimSuffix(filepath.Base(artifact.Name), ext)
-			artifact.Name = fmt.Sprintf("%s-%s%s", name, timestamp, ext)
-		}
+		artifact.Name = deployName
 
 		a.logger.Printf("  Export [ %s => $BITRISE_DEPLOY_DIR/%s ]", artifactName, artifact.Name)
 


### PR DESCRIPTION
Split out of the (now closed) SSW-3065 artifact map PR #62, where this turned up. Nothing here depends on that work.

## The bug

Artifacts of different variants share a base name — every module's mapping file is `mapping.txt`, and `assemble` over several variants produces one per variant — while `$BITRISE_DEPLOY_DIR` is flat. `exportArtifacts` handles that by renaming a colliding file to `<base>-<timestamp>.<ext>`, but

- the timestamp has **second** resolution, and
- the suffixed name was **never re-checked**.

So when a run exports two same-named files within the same second, both get the *same* new name and the second copy silently overwrites the first. The step still reports success, `BITRISE_MAPPING_PATH_LIST` lists the same path twice, and one variant's mapping file is simply gone — with a name that suggests it is there.

Reproduced on CI while working on #62: two variants' mapping files both landed as `another_app-mapping-20260819084035.txt`.

## The fix

`freeDeployName` keeps suffixing until the name is actually free:

```
mapping.txt → mapping-20260819084035.txt → mapping-20260819084035-2.txt → …
```

After 100 attempts it warns and returns the last candidate rather than failing a build that otherwise succeeded — overwriting one file is a better outcome than losing the whole build's artifacts, and 100 same-named exports in one second is not a real scenario.

Also: `fmt.Errorf("failed to export environment variable: %s", envKey)` dropped the envman error itself, so a failing export gave no clue why. Now `%w`-wrapped.

## Testing

`Test_freeDeployName_SameSecondCollision` exports three same-named mapping files back to back (all within one second) and asserts that each name still holds its own variant's content. Against the old code the third assertion fails.

Uses the vendored `testify/assert` (the module doesn't vendor `require`), matching the existing tests in `step/step_test.go`.